### PR TITLE
Loosen SFT CSP restrictions

### DIFF
--- a/apps/racing/sonic-forces/tracker/src/main/tracker/server_components/http_server.clj
+++ b/apps/racing/sonic-forces/tracker/src/main/tracker/server_components/http_server.clj
@@ -170,7 +170,8 @@
                                                                                        :img-src "data:"
                                                                                        ;; really?!
                                                                                        :style-src "'self' 'unsafe-inline' https://fonts.googleapis.com"
-                                                                                       :script-src "'self' 'unsafe-inline'"}}
+                                                                                       ;; TODO: unsafe-eval should only be in debug mode
+                                                                                       :script-src "'self' 'unsafe-inline' 'unsafe-eval'"}}
                              ::http/type :immutant}]
            (log/info "Creatting HTTP Server with config " (with-out-str (pprint local-config))
                      " based on keys "


### PR DESCRIPTION
Allow unsafe-eval. It's a terrible idea outside debug mode, but
required for REPL interaction.

And, really, big-picture, there doesn't seem a way to avoid it.