### PR TITLE
Roadblocks/3 in worker

### DIFF
--- a/apps/racing/roadblocks/README.md
+++ b/apps/racing/roadblocks/README.md
@@ -45,6 +45,17 @@ TODO: look into the sft folder to see how they set up deps.edn.
 
 If you install it "globally," you can use the `shadow-cljs` command directly.
 
+### Short Version
+
+`$ shadow-cljs clj-repl`
+
+`[2:0]~shadow.user=> (shadow/watch :app)
+
+That will print instructions for connecting the browser and your
+editor's nrepl client.
+
+Read on for more generic details that probably don't belong in here.
+
 ### Common Commands
 
 Compile a build once and exit:
@@ -105,14 +116,6 @@ much faster.
 #### Specific Build Targets
 
 Mostly, you'll want to run builds for specific target.
-
-##### Short Version
-
-`$ shadow-cljs clj-repl`
-
-`[2:0]~shadow.user=> (shadow/watch :app)
-
-Read on for more generic details that probably don't belong in here.
 
 ##### CLI
 

--- a/apps/racing/roadblocks/src/cljs/frereth/apps/roadblocks/window_manager.cljs
+++ b/apps/racing/roadblocks/src/cljs/frereth/apps/roadblocks/window_manager.cljs
@@ -277,14 +277,14 @@
       [{:keys [::worker/need-dom-animation?]
         :as worker-manager}
        action world-key worker event
-       {pixels :frereth/body
+       {img-bmp :frereth/body
         worker-clock ::lamport/clock
         :as raw-message}]
       (.info js/console "Handling render request:" raw-message)
       ;; Need to update the Material.
       ;; Which seems like it probably means a recompilation.
       ;; Oh well. There aren't a lot of alternatives.
-      (let [texture (build-texture-from-raw-bytes pixels)
+      (let [texture (THREE/CanvasTexture. img-bmp)
             material (.-material cube)]
         (set! (.-map material) texture)
         ;; We are getting here.
@@ -298,7 +298,7 @@
         ;; seems guaranteed to suck?
         ;; (Yes, premature optimization and all that, but this approach
         ;; is pretty much guaranteed to be awful)
-        (set! (.-needsUpdate (.-texture material)) true))
+        (set! (.-needsUpdate (.-map material)) true))
       (when need-dom-animation?
         (comment
           (js/requestAnimationFrame (fn [clock-tick]

--- a/apps/racing/roadblocks/src/cljs/frereth/apps/roadblocks/worker.cljs
+++ b/apps/racing/roadblocks/src/cljs/frereth/apps/roadblocks/worker.cljs
@@ -152,6 +152,8 @@
             ;; establish here.
             ;; So it isn't something to just automate away.
             renderer (THREE/WebGLRenderer. #js{:canvas canvas})
+            ;; Leaving this around, because, really, it's what I want
+            ;; to do.
             #_(THREE/WebGLRenderer. #js {:canvas (clj->js mock-canvas)})
             render-target (THREE/WebGLRenderTarget. w h)]
         #_(.setRenderTarget renderer render-target)
@@ -250,8 +252,9 @@
           clone (.clone texture)
           image (.-image clone)
           canvas (::ui/canvas destination)
-          conversion-promise (.convertToBlob canvas)]
-      (.then conversion-promise
+          #_#_conversion-promise (.convertToBlob canvas)
+          img-bmp (.transferToImageBitmap canvas)]
+      #_(.then conversion-promise
              (fn [blob]
                (.then (.arrayBuffer blob)
                       (fn [a-b]
@@ -282,7 +285,11 @@
                         ;; optimization etc.
                         (comment
                           (when has-animator
-                            (js/requestAnimationFrame (partial render-and-animate! clock renderer)))))))))))
+                            (js/requestAnimationFrame (partial render-and-animate! clock renderer))))))))
+      (shared-worker/transfer-to-worker! clock
+                                         js/self
+                                         :frereth/render
+                                         img-bmp))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;; Event handlers

--- a/apps/racing/roadblocks/src/cljs/frereth/apps/roadblocks/worker.cljs
+++ b/apps/racing/roadblocks/src/cljs/frereth/apps/roadblocks/worker.cljs
@@ -147,7 +147,7 @@
             ;; red flags about breaking the encapsulation I'm trying to
             ;; establish here.
             ;; So it isn't something to just automate away.
-            renderer #_(THREE/WebGLRenderer. #js {:canvas (clj->js mock-canvas)}) (THREE/WebGLRenderer. canvas)
+            renderer #_(THREE/WebGLRenderer. #js {:canvas (clj->js mock-canvas)}) (THREE/WebGLRenderer. #js{:canvas canvas})
             render-target (THREE/WebGLRenderTarget. w h)]
         (.setRenderTarget renderer render-target)
         (swap! state into {::camera {::fov fov
@@ -235,6 +235,20 @@
   ;; to be able to gracefully recover from those
   (throw (js/Error. "Not Implemented")))
 
+(defmethod handle-incoming-message!   :frereth/event
+  ;; UI event
+  [_ {[tag ctrl-id event] :frereth/body} data]
+  (.log js/console "Should dispatch" event "to" ctrl-id "based on" tag)
+  (try
+    (.error js/console "What does this mean in this context?")
+    (catch :default ex
+      (.error js/console ex))))
+
+(defmethod handle-incoming-message! :frereth/forward
+  ;; Data passed-through from server
+  [_ data]
+  (.warn js/console "Worker should handle" data))
+
 (defmethod handle-incoming-message! :frereth/halt
   [_ _]
   (.log js/console "World halted. Exiting.")
@@ -263,20 +277,6 @@
       (.dispose (.-map (.-material mesh))))
     (.dispose scene))
   (reset! state (create-initial-state)))
-
-(defmethod handle-incoming-message!   :frereth/event
-  ;; UI event
-  [_ {[tag ctrl-id event] :frereth/body} data]
-  (.log js/console "Should dispatch" event "to" ctrl-id "based on" tag)
-  (try
-    (.error js/console "What does this mean in this context?")
-    (catch :default ex
-      (.error js/console ex))))
-
-(defmethod handle-incoming-message! :frereth/forward
-  ;; Data passed-through from server
-  [_ data]
-  (.warn js/console "Worker should handle" data))
 
 (defmethod handle-incoming-message! :frereth/main
   [_

--- a/apps/racing/roadblocks/src/cljs/frereth/apps/shared/worker.cljs
+++ b/apps/racing/roadblocks/src/cljs/frereth/apps/shared/worker.cljs
@@ -314,9 +314,24 @@
   ;; that.
   (let [raw-data (.-data event)
         {:keys [:frereth/action]
-         :as data} (serial/deserialize raw-data)]
+         other-clock-tick ::lamport/clock
+         :as data} (if (not= "raw" (.-type raw-data))
+                     ;; Structured event data that we need to deserialize
+                     (serial/deserialize raw-data)
+                     ;; It seems like there really ought to be a built-in
+                     ;; to do this sort of thing.
+                     ;; clojure.walk has keywordize-keys which is close,
+                     ;; but seems like it would be more verbose
+                     {:frereth/action (keyword "frereth" (.-action raw-data))
+                      :frereth/body (.-body raw-data)
+                      ::lamport/clock (.-clock raw-data)
+                      :frereth/type :frereth/raw})]
     (.log js/console "Message from" worker ":" action "in" data)
-    (lamport/do-tick clock)
+    ;; This might have a clock-tick. Deciding how to keep clients
+    ;; from knowing about that detail is an important API detail
+    (if other-clock-tick
+      (lamport/do-tick clock other-clock-tick)
+      (lamport/do-tick clock))
     (handle-worker-message this action world-key worker event data)))
 
 (s/fdef fork-world-worker
@@ -381,6 +396,10 @@
        ;; an affinity setting to avoid thrashing things like texture
        ;; memory
        ;; FIXME: Work that out
+       ;; Q: If I hung onto a reference to this worker-canvas, could
+       ;; I do anything useful with it? Like transfer textures?
+       ;; It's a different WebGL rendering context. So surely the answer
+       ;; is "No"...isn't it?
        (transfer-to-worker! clock
                             worker
                             :frereth/main

--- a/apps/racing/roadblocks/src/cljs/frereth/apps/shared/worker.cljs
+++ b/apps/racing/roadblocks/src/cljs/frereth/apps/shared/worker.cljs
@@ -396,10 +396,6 @@
        ;; an affinity setting to avoid thrashing things like texture
        ;; memory
        ;; FIXME: Work that out
-       ;; Q: If I hung onto a reference to this worker-canvas, could
-       ;; I do anything useful with it? Like transfer textures?
-       ;; It's a different WebGL rendering context. So surely the answer
-       ;; is "No"...isn't it?
        (transfer-to-worker! clock
                             worker
                             :frereth/main

--- a/clojure/frereth/docs/architecture.org
+++ b/clojure/frereth/docs/architecture.org
@@ -1,3 +1,5 @@
+* TODO Convert this to asciidoc
+
 * Why?
 
 Frereth's goal is to make it easier, simpler, and more fun
@@ -154,4 +156,3 @@ to be running in the same process on one piece
 of hardware.
 
 ** Programming Language Optimizations
-


### PR DESCRIPTION
Fix the way THREE gets initialized in Worker

Then transfer the contents of the Worker's canvas  back to the
main thread so it can update the Material for its spinning cube.

That's an empty gray now, but it's forward progress.